### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-python-prints.yml
+++ b/.github/workflows/check-python-prints.yml
@@ -1,4 +1,6 @@
 name: Check for print() in Python files
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/VUTP-University/phd-lab-utp/security/code-scanning/2](https://github.com/VUTP-University/phd-lab-utp/security/code-scanning/2)

To fix the problem, explicitly set the required minimal permissions for the workflow/job by adding a `permissions` block. As this workflow only needs to check out code and read file contents, the minimal permission is `contents: read`. This should be added either to the top-level of the workflow (so all jobs inherit it), or directly under the `check-prints` job if you anticipate extending the workflow later with other jobs with different needs. The recommended place is just beneath the `name` line, following the GitHub Actions convention. No new imports, methods, or code structure changes are required; only the addition of the `permissions` section in the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
