### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-console.logs.yml
+++ b/.github/workflows/check-console.logs.yml
@@ -1,4 +1,6 @@
 name: Check for console.log() in JS files
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/VUTP-University/phd-lab-utp/security/code-scanning/1](https://github.com/VUTP-University/phd-lab-utp/security/code-scanning/1)

To fix the problem, explicitly add a `permissions` block at a scope that applies to the job(s) performing GitHub operations. The simplest and cleanest way is to add `permissions: contents: read` at the workflow root (top-level, just under the name or on), ensuring all jobs inherit these minimum required privileges. This fits the job's needs, which only require reading repository content. No further permissions (such as `write`) are necessary. Specifically, add the new `permissions` field after the `name` field and before `on`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
